### PR TITLE
Expose a testing crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ evercrypt_provider/target
 no-std-support-check/target
 rust_crypto_provider/target
 traits/target/
+hpke-rs-tests/target
 .DS_Store
 /.idea

--- a/hpke-rs-tests/Cargo.toml
+++ b/hpke-rs-tests/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "hpke-rs-tests"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hpke-rs = { version = "0.2.0", features = [
+  "hazmat",
+  "serialization",
+  "hpke-test",
+], path = "../" }
+hpke-rs-crypto = { version = "0.2.0", path = "../traits" }
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+rayon = "1.5"
+log = "0.4"
+pretty_env_logger = "0.5"
+
+[features]
+prng = ["hpke-rs/hpke-test-prng"]

--- a/hpke-rs-tests/Cargo.toml
+++ b/hpke-rs-tests/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "hpke-rs-tests"
 version = "0.1.0"
+authors = [ "Cryspen" ]
 edition = "2021"
+license = "MPL-2.0"
+readme = "Readme.md"
+description = "Tests for crypto providers"
+repository = "https://github.com/franziskuskiefer/hpke-rs"
 
 [dependencies]
 hpke-rs = { version = "0.2.0", features = [

--- a/hpke-rs-tests/Readme.md
+++ b/hpke-rs-tests/Readme.md
@@ -1,0 +1,19 @@
+# Tests for Crypto Providers
+
+This crate exposes macros that define crypto provider test functions.
+
+## Usage
+
+```rust
+struct MyCryptoProvider;
+
+impl hpke_rs_crypto::CryptoProvider for MyCryptoProvider {
+    // ...
+}
+
+#[cfg(tests)]
+mod tests {
+    hpke_rs_tests::test_funs!(MyCryptoProvider);
+    hpke_rs_tests::kat_fun!(MyCryptoProvider);
+}
+```

--- a/hpke-rs-tests/src/lib.rs
+++ b/hpke-rs-tests/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod test_hpke;
+pub mod test_hpke_kat;
+
+pub use hpke_rs;
+pub use hpke_rs_crypto;
+pub use serde;
+pub use serde_json;
+
+mod util;

--- a/hpke-rs-tests/src/test_hpke_kat.rs
+++ b/hpke-rs-tests/src/test_hpke_kat.rs
@@ -1,0 +1,334 @@
+use std::convert::TryInto;
+use std::time::Instant;
+
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use serde::{Deserialize, Serialize};
+
+use hpke_rs::prelude::{Hpke, HpkeMode, HpkePrivateKey, HpkePublicKey};
+use hpke_rs_crypto::{types::*, HpkeCrypto};
+
+use crate::util::{hex_to_bytes, hex_to_bytes_option, vec_to_option_slice};
+
+static TEST_JSON: &[u8] = include_bytes!("test_vectors.json");
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(non_snake_case)]
+pub struct HpkeTestVector {
+    mode: u8,
+    kem_id: u16,
+    kdf_id: u16,
+    aead_id: u16,
+    info: String,
+    ikmR: String,
+    ikmS: Option<String>,
+    ikmE: String,
+    skRm: String,
+    skSm: Option<String>,
+    skEm: String,
+    psk: Option<String>,
+    psk_id: Option<String>,
+    pkRm: String,
+    pkSm: Option<String>,
+    pkEm: String,
+    enc: String,
+    shared_secret: String,
+    key_schedule_context: String,
+    secret: String,
+    key: String,
+    base_nonce: String,
+    exporter_secret: String,
+    encryptions: Vec<CiphertextKAT>,
+    exports: Vec<ExportsKAT>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(non_snake_case)]
+struct CiphertextKAT {
+    aad: String,
+    ct: String,
+    nonce: String,
+    pt: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(non_snake_case)]
+struct ExportsKAT {
+    exporter_context: String,
+    L: usize,
+    exported_value: String,
+}
+
+pub fn kat<Crypto: HpkeCrypto + 'static>(tests: Vec<HpkeTestVector>) {
+    tests.into_par_iter().for_each(|test| {
+        let mode: HpkeMode = test.mode.try_into().unwrap();
+        let kem_id: KemAlgorithm = test.kem_id.try_into().unwrap();
+        let kdf_id: KdfAlgorithm = test.kdf_id.try_into().unwrap();
+        let aead_id: AeadAlgorithm = test.aead_id.try_into().unwrap();
+
+        if Crypto::supports_kem(kem_id).is_err() {
+            log::trace!(
+                " > KEM {:?} not implemented yet for {}",
+                kem_id,
+                Crypto::name()
+            );
+            return;
+        }
+
+        if Crypto::supports_aead(aead_id).is_err() {
+            log::trace!(
+                " > AEAD {:?} not implemented yet for {}",
+                aead_id,
+                Crypto::name()
+            );
+            return;
+        }
+
+        if Crypto::supports_kdf(kdf_id).is_err() {
+            log::trace!(
+                " > KDF {:?} not implemented yet for {}",
+                kdf_id,
+                Crypto::name()
+            );
+            return;
+        }
+
+        log::trace!(
+            "Testing mode {:?} with ciphersuite {:?}_{:?}_{:?}",
+            mode,
+            kem_id,
+            kdf_id,
+            aead_id
+        );
+
+        // Init HPKE with the given mode and ciphersuite.
+        let mut hpke = Hpke::<Crypto>::new(mode, kem_id, kdf_id, aead_id);
+
+        // Set up sender and receiver.
+        let pk_rm = HpkePublicKey::new(hex_to_bytes(&test.pkRm));
+        let sk_rm = HpkePrivateKey::new(hex_to_bytes(&test.skRm));
+        let pk_em = HpkePublicKey::new(hex_to_bytes(&test.pkEm));
+        let sk_em = HpkePrivateKey::new(hex_to_bytes(&test.skEm));
+        let pk_sm = hex_to_bytes_option(test.pkSm);
+        let pk_sm = if pk_sm.is_empty() {
+            None
+        } else {
+            Some(HpkePublicKey::new(pk_sm))
+        };
+        let pk_sm = pk_sm.as_ref();
+        let sk_sm = hex_to_bytes_option(test.skSm);
+        let sk_sm = if sk_sm.is_empty() {
+            None
+        } else {
+            Some(HpkePrivateKey::new(sk_sm))
+        };
+        let sk_sm = sk_sm.as_ref();
+        let info = hex_to_bytes(&test.info);
+        let psk = hex_to_bytes_option(test.psk);
+        let psk = vec_to_option_slice(&psk);
+        let psk_id = hex_to_bytes_option(test.psk_id);
+        let psk_id = vec_to_option_slice(&psk_id);
+        let shared_secret = hex_to_bytes(&test.shared_secret);
+        let key = hex_to_bytes(&test.key);
+        let nonce = hex_to_bytes(&test.base_nonce);
+        let exporter_secret = hex_to_bytes(&test.exporter_secret);
+
+        // Input key material.
+        let ikm_r = hex_to_bytes(&test.ikmR);
+        let ikm_e = hex_to_bytes(&test.ikmE);
+        let ikm_s = hex_to_bytes_option(test.ikmS);
+
+        // Use internal `key_schedule` function for KAT.
+        let mut direct_ctx = hpke
+            .key_schedule(
+                &shared_secret,
+                &info,
+                psk.unwrap_or_default(),
+                psk_id.unwrap_or_default(),
+            )
+            .unwrap();
+
+        // Check setup info
+        // Note that key and nonce are empty for exporter only key derivation.
+        assert_eq!(direct_ctx.key(), key);
+        assert_eq!(direct_ctx.nonce(), nonce);
+        assert_eq!(direct_ctx.exporter_secret(), exporter_secret);
+        assert_eq!(direct_ctx.sequence_number(), 0);
+
+        // Test key pair derivation.
+        let (my_sk_r, my_pk_r) = hpke.derive_key_pair(&ikm_r).unwrap().into_keys();
+        assert_eq!(sk_rm, my_sk_r);
+        assert_eq!(pk_rm, my_pk_r);
+        let (my_sk_e, my_pk_e) = hpke.derive_key_pair(&ikm_e).unwrap().into_keys();
+        assert_eq!(sk_em, my_sk_e);
+        assert_eq!(pk_em, my_pk_e);
+        if let (Some(sk_sm), Some(pk_sm)) = (sk_sm, pk_sm) {
+            let (my_sk_s, my_pk_s) = hpke.derive_key_pair(&ikm_s).unwrap().into_keys();
+            assert_eq!(sk_sm, &my_sk_s);
+            assert_eq!(pk_sm, &my_pk_s);
+        }
+
+        // Setup KAT receiver.
+        let kat_enc = hex_to_bytes(&test.enc);
+        let mut receiver_context_kat = hpke
+            .setup_receiver(&kat_enc, &sk_rm, &info, psk, psk_id, pk_sm)
+            .unwrap();
+
+        // Setup sender and receiver with KAT randomness.
+        // We first have to inject the randomness (ikmE).
+
+        #[cfg(feature = "prng")]
+        {
+            log::trace!("Testing with known ikmE ...");
+            let mut hpke_sender = Hpke::<Crypto>::new(mode, kem_id, kdf_id, aead_id);
+            // This only works when seeding the PRNG with ikmE.
+            hpke_sender.seed(&ikm_e).expect("Error injecting ikm_e");
+            let (enc, _sender_context_kat) = hpke_sender
+                .setup_sender(&pk_rm, &info, psk, psk_id, sk_sm)
+                .unwrap();
+            let receiver_context = hpke
+                .setup_receiver(&enc, &sk_rm, &info, psk, psk_id, pk_sm)
+                .unwrap();
+            assert_eq!(enc, kat_enc);
+            assert_eq!(receiver_context.key(), receiver_context_kat.key());
+            assert_eq!(receiver_context.nonce(), receiver_context_kat.nonce());
+            assert_eq!(
+                receiver_context.exporter_secret(),
+                receiver_context_kat.exporter_secret()
+            );
+            receiver_context_kat = receiver_context;
+            assert_eq!(receiver_context_kat.key(), key);
+            assert_eq!(receiver_context_kat.nonce(), nonce);
+            assert_eq!(receiver_context_kat.exporter_secret(), exporter_secret);
+            assert_eq!(receiver_context_kat.sequence_number(), 0);
+        }
+
+        // Setup sender and receiver for self tests.
+        let (enc, mut sender_context) = hpke
+            .setup_sender(&pk_rm, &info, psk, psk_id, sk_sm)
+            .unwrap();
+        let mut receiver_context = hpke
+            .setup_receiver(&enc, &sk_rm, &info, psk, psk_id, pk_sm)
+            .unwrap();
+
+        // Encrypt
+        for (_i, encryption) in test.encryptions.iter().enumerate() {
+            // Cloning the Hpke object renews the test PRNG.
+            hpke = hpke.clone();
+            println!("Test encryption {} ...", _i);
+            let aad = hex_to_bytes(&encryption.aad);
+            let ptxt = hex_to_bytes(&encryption.pt);
+            let ctxt_kat = hex_to_bytes(&encryption.ct);
+
+            // Test context API self-test
+            let ctxt_out = sender_context.seal(&aad, &ptxt).unwrap();
+            let ptxt_out = receiver_context.open(&aad, &ctxt_out).unwrap();
+            assert_eq!(ptxt_out, ptxt);
+
+            // Test single-shot API self-test
+            let (enc, ct) = hpke
+                .seal(&pk_rm, &info, &aad, &ptxt, psk, psk_id, sk_sm)
+                .unwrap();
+            let ptxt_out = hpke
+                .open(&enc, &sk_rm, &info, &aad, &ct, psk, psk_id, pk_sm)
+                .unwrap();
+            assert_eq!(ptxt_out, ptxt);
+
+            // Test KAT receiver context open
+            let ptxt_out = receiver_context_kat.open(&aad, &ctxt_kat).unwrap();
+            assert_eq!(ptxt_out, ptxt);
+
+            // Test KAT seal on direct_ctx
+            let ct = direct_ctx.seal(&aad, &ptxt).unwrap();
+            assert_eq!(ctxt_kat, ct);
+        }
+
+        // Test KAT on direct_ctx for exporters
+        for (_i, export) in test.exports.iter().enumerate() {
+            println!("Test exporter {} ...", _i);
+            let export_context = hex_to_bytes(&export.exporter_context);
+            let export_value = hex_to_bytes(&export.exported_value);
+            let length = export.L;
+
+            let exported_secret = direct_ctx.export(&export_context, length).unwrap();
+            assert_eq!(export_value, exported_secret);
+        }
+    });
+}
+
+pub fn test_kat<Crypto: HpkeCrypto + 'static>() {
+    let _ = pretty_env_logger::try_init();
+    let mut reader = TEST_JSON;
+    let tests: Vec<HpkeTestVector> = match serde_json::from_reader(&mut reader) {
+        Ok(r) => r,
+        Err(e) => panic!("Error reading file.\n{:?}", e),
+    };
+
+    let now = Instant::now();
+    kat::<Crypto>(tests.clone());
+    let time = now.elapsed();
+    log::info!("Test vectors with Rust Crypto took: {}s", time.as_secs());
+
+    // let now = Instant::now();
+    // kat::<HpkeEvercrypt>(tests);
+    // let time = now.elapsed();
+    // log::info!("Test vectors with Evercrypt took: {}s", time.as_secs());
+}
+
+#[macro_export]
+macro_rules! kat_fun {
+    ($provider:ty) => {
+        #[test]
+        fn test_kat() {
+            $crate::test_hpke_kat::test_kat::<$provider>();
+        }
+
+        #[test]
+        fn test_serialization() {
+            use $crate::hpke_rs::prelude::{
+                Hpke, HpkeKeyPair, HpkeMode, HpkePrivateKey, HpkePublicKey,
+            };
+            use $crate::hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
+            use $crate::serde_json;
+
+            // XXX: Make these individual tests.
+            for mode in 0u8..4 {
+                let hpke_mode = HpkeMode::try_from(mode).unwrap();
+                for aead_mode in 1u16..4 {
+                    let aead_mode = AeadAlgorithm::try_from(aead_mode).unwrap();
+                    for kdf_mode in 1u16..4 {
+                        let kdf_mode = KdfAlgorithm::try_from(kdf_mode).unwrap();
+                        for &kem_mode in &[0x10u16, 0x20] {
+                            let kem_mode = KemAlgorithm::try_from(kem_mode).unwrap();
+
+                            let mut hpke =
+                                Hpke::<$provider>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
+
+                            // JSON: Public, Private, KeyPair
+                            let key_pair = hpke.generate_key_pair().unwrap();
+
+                            let serialized_key_pair = serde_json::to_string(&key_pair).unwrap();
+                            let deserialized_key_pair: HpkeKeyPair =
+                                serde_json::from_str(&serialized_key_pair).unwrap();
+
+                            let (sk, pk) = key_pair.into_keys();
+
+                            let serialized_sk = serde_json::to_string(&sk).unwrap();
+                            let deserialized_sk: HpkePrivateKey =
+                                serde_json::from_str(&serialized_sk).unwrap();
+                            let serialized_pk = serde_json::to_string(&pk).unwrap();
+                            let deserialized_pk: HpkePublicKey =
+                                serde_json::from_str(&serialized_pk).unwrap();
+
+                            let (des_sk, des_pk) = deserialized_key_pair.into_keys();
+
+                            assert_eq!(pk, des_pk);
+                            assert_eq!(pk, deserialized_pk);
+                            assert_eq!(sk.as_slice(), des_sk.as_slice());
+                            assert_eq!(sk.as_slice(), deserialized_sk.as_slice());
+                        }
+                    }
+                }
+            }
+        }
+    };
+}

--- a/hpke-rs-tests/src/test_hpke_kat.rs
+++ b/hpke-rs-tests/src/test_hpke_kat.rs
@@ -65,6 +65,8 @@ pub fn kat<Crypto: HpkeCrypto + 'static>(tests: Vec<HpkeTestVector>) {
         let kdf_id: KdfAlgorithm = test.kdf_id.try_into().unwrap();
         let aead_id: AeadAlgorithm = test.aead_id.try_into().unwrap();
 
+        let ciphersuite_string = format!("{mode}/{kem_id}/{kdf_id}/{aead_id}");
+
         if Crypto::supports_kem(kem_id).is_err() {
             println!(
                 " > KEM {:?} not implemented yet for {}",

--- a/hpke-rs-tests/src/util.rs
+++ b/hpke-rs-tests/src/util.rs
@@ -1,0 +1,28 @@
+/// Convert a hex string to a byte vector.
+pub fn hex_to_bytes(hex: &str) -> Vec<u8> {
+    assert!(hex.len() % 2 == 0);
+    let mut bytes = Vec::new();
+    for i in 0..(hex.len() / 2) {
+        bytes.push(u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).unwrap());
+    }
+    bytes
+}
+
+/// Convert a hex string to a byte vector.
+/// If the input is `None`, this returns an empty vector.
+pub fn hex_to_bytes_option(hex: Option<String>) -> Vec<u8> {
+    match hex {
+        Some(s) => hex_to_bytes(&s),
+        None => vec![],
+    }
+}
+
+/// Convert a byte slice into byte slice option.
+/// Returns `Nonce` if the byte slice is empty and `Some(v)` otherwise.
+pub fn vec_to_option_slice(v: &[u8]) -> Option<&[u8]> {
+    if v.is_empty() {
+        None
+    } else {
+        Some(v)
+    }
+}

--- a/rust_crypto_provider/Cargo.toml
+++ b/rust_crypto_provider/Cargo.toml
@@ -31,6 +31,7 @@ rand_chacha = { version = "0.3", default-features = false }
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 rand = { version = "0.8" }
+hpke-rs-tests = { path = "../hpke-rs-tests/" }
 
 [features]
 deterministic-prng = [

--- a/rust_crypto_provider/src/lib.rs
+++ b/rust_crypto_provider/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../Readme.md")]
-#![cfg_attr(not(test), no_std)]
+//#![cfg_attr(not(test), no_std)]
 
 extern crate alloc;
 

--- a/rust_crypto_provider/tests/hpke-rs-tests.rs
+++ b/rust_crypto_provider/tests/hpke-rs-tests.rs
@@ -1,0 +1,6 @@
+#![allow(non_snake_case)]
+
+use hpke_rs_tests::{kat_fun, test_funs};
+
+test_funs!(hpke_rs_rust_crypto::HpkeRustCrypto);
+kat_fun!(hpke_rs_rust_crypto::HpkeRustCrypto);

--- a/src/dh_kem.rs
+++ b/src/dh_kem.rs
@@ -166,12 +166,15 @@ pub(super) fn auth_decaps<Crypto: HpkeCrypto>(
     suite_id: &[u8],
 ) -> Result<Vec<u8>, Error> {
     let pk_e = deserialize(enc);
+    std::println!("alg:  {alg:?}");
+    std::println!("pk_e: {pk_e:?}");
+    std::println!("pk_s: {pk_s:?}");
     let dh_pk = concat(&[
-        &Crypto::kem_derive(alg, &pk_e, sk_r)?,
-        &Crypto::kem_derive(alg, pk_s, sk_r)?,
+        &Crypto::kem_derive(alg, &pk_e, sk_r).unwrap(),
+        &Crypto::kem_derive(alg, pk_s, sk_r).unwrap(),
     ]);
 
-    let pk_rm = serialize(&Crypto::kem_derive_base(alg, sk_r)?);
+    let pk_rm = serialize(&Crypto::kem_derive_base(alg, sk_r).unwrap());
     let pk_sm = serialize(pk_s);
     let kem_context = concat(&[enc, &pk_rm, &pk_sm]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,7 +523,7 @@ impl<Crypto: HpkeCrypto> Hpke<Crypto> {
         psk_id: Option<&[u8]>,
         pk_s: Option<&HpkePublicKey>,
     ) -> Result<Plaintext, HpkeError> {
-        let mut context = self.setup_receiver(enc, sk_r, info, psk, psk_id, pk_s)?;
+        let mut context = self.setup_receiver(enc, sk_r, info, psk, psk_id, pk_s).unwrap();
         context.open(aad, ct)
     }
 


### PR DESCRIPTION
The testing crate can be used by provider implementers to run the HPKE test suite using their own provider. We specifically need to to run the tests against the libcrux-backed provider.